### PR TITLE
Configure TwitchBox for Stream Manager dashboard

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -29,16 +29,12 @@ fn main() {
 		main_window.eval("window.addEventListener('keydown', function(e) {if (e.ctrlKey && e.shiftKey && e.keyCode == 88) { e.preventDefault(); }});").unwrap(); // CTRL + SHIFT + X
 		// DISABLE DEVELOPER OPTIONS ============================================================= //
 		main_window.eval("window.addEventListener('keydown', function(e) {if (e.ctrlKey && e.shiftKey && e.keyCode == 73) { e.preventDefault(); }});").unwrap(); // CTRL + SHIFT + I
-		// DISABLE FIND IN PAGE ================================================================== //
-		main_window.eval("window.addEventListener('keydown', function(e) {if (e.ctrlKey && e.keyCode == 70) { e.preventDefault(); }});").unwrap(); // CTRL + F
-		main_window.eval("window.addEventListener('keydown', function(e) {if (e.ctrlKey && e.keyCode == 71) { e.preventDefault(); }});").unwrap(); // CTRL + G
-		main_window.eval("window.addEventListener('keydown', function(e) {if (e.keyCode == 114) { e.preventDefault(); }});").unwrap(); // F3
+		// FIND IN PAGE ENABLED for Stream Manager dashboard search
 		// DISABLE CARET BROWSING ================================================================ //
 		main_window.eval("window.addEventListener('keydown', function(e) {if (e.keyCode == 118) { e.preventDefault(); }});").unwrap(); // F7
 		// DISABLE MIDDLE-CLICK TO OPEN LINKS IN NEW WINDOWS ===================================== //
 		main_window.eval("window.addEventListener('auxclick', function(e) {if (e.button == 1) { e.preventDefault(); }});").unwrap();
-		// DISABLE RIGHT CLICK =================================================================== //
-		main_window.eval("window.addEventListener('contextmenu', function(e) { e.preventDefault(); });").unwrap();
+		// RIGHT CLICK ENABLED for Stream Manager mod tools
 		Ok(())
 	})
 	.plugin(tauri_plugin_window_state::Builder::default().build())

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -37,8 +37,8 @@
         "icons/icon.ico"
       ],
       "identifier": "com.twitchbox.app",
-      "longDescription": "An opensource Windows client for Twitch.tv",
-      "shortDescription": "An opensource Windows client for Twitch.tv",
+      "longDescription": "An opensource Windows client for Twitch.tv Stream Manager",
+      "shortDescription": "An opensource Windows client for Twitch.tv Stream Manager",
       "resources": [],
       "externalBin": [],
       "targets": "all",
@@ -83,10 +83,10 @@
     },
     "windows": [
       {
-        "title": "TwitchBox",
+        "title": "TwitchBox - Stream Manager",
         "minWidth": 1400,
         "minHeight": 700,
-        "url": "https://twitch.tv",
+        "url": "https://dashboard.twitch.tv/u/ticklefitz/stream-manager",
         "fullscreen": false,
         "focus": true,
         "resizable": true,


### PR DESCRIPTION
- Changed default URL to dashboard.twitch.tv/u/ticklefitz/stream-manager
- Updated window title to "TwitchBox - Stream Manager"
- Re-enabled right-click context menu for mod tools
- Re-enabled find-in-page (Ctrl+F/G, F3) for dashboard search
- Updated bundle descriptions to reflect Stream Manager usage

https://claude.ai/code/session_01EhdSyZpaAdkBctdmmLJXjK